### PR TITLE
check

### DIFF
--- a/test/unit/test_graph_rewrite.py
+++ b/test/unit/test_graph_rewrite.py
@@ -203,7 +203,7 @@ class TestGEPAndVectorizeRewrite(unittest.TestCase):
 
 
 import inspect
-from tinygrad.ops import graph_rewrite, _substitute, track_rewrites, symbolic_simple
+from tinygrad.ops import graph_rewrite, _substitute, symbolic_simple
 
 class TestBottomUpRewrite(unittest.TestCase):
   def test_const_folding(self):
@@ -214,7 +214,6 @@ class TestBottomUpRewrite(unittest.TestCase):
     self.assertIs(gt, ret)
 
 # normally .substitute would be fine, but it's not tracked
-@track_rewrites()
 def named_substitute(name:str, uop:UOp, rel:dict[UOp, UOp]): return graph_rewrite(uop, _substitute, rel, bottom_up=True)
 def substitute(uop:UOp, rel:dict[UOp, UOp]): return named_substitute(inspect.stack()[1].function, uop, rel)
 

--- a/tinygrad/codegen/kernel.py
+++ b/tinygrad/codegen/kernel.py
@@ -6,7 +6,7 @@ from typing import Optional, cast, Final, Callable, Sequence
 from enum import Enum, auto
 
 from tinygrad.ops import GroupOp, KernelInfo, UOp, Ops, can_pad, print_uops, type_verify, resolve, Variable, sint, \
-  graph_rewrite, track_rewrites, view_left
+  graph_rewrite, view_left
 from tinygrad.device import Device
 from tinygrad.renderer import Renderer, TensorCore, ProgramSpec
 from tinygrad.dtype import ImageDType
@@ -651,7 +651,6 @@ class Kernel:
 
   # **** this is the lowerer ****
 
-  @track_rewrites()
   def linearize(self) -> Kernel:
     modified_ast = self.get_optimized_ast()
 

--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -1,7 +1,7 @@
 import sys, atexit, functools, pickle
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
-from tinygrad.ops import GroupOp, UOp, Ops, PatternMatcher, UPat, Variable, can_pad, graph_rewrite, resolve, track_rewrites, view_left, merge_views
+from tinygrad.ops import GroupOp, UOp, Ops, PatternMatcher, UPat, Variable, can_pad, graph_rewrite, resolve, view_left, merge_views
 from tinygrad.ops import identity_element, buffers, symbolic_simple, type_verify
 from tinygrad.helpers import Context, Metadata, all_int, all_same, colored, diskcache_put, merge_dicts, prod, dedup, getenv, unwrap
 from tinygrad.helpers import FUSE_CONV_BW, FUSE_ARANGE, DEBUG, ContextVar
@@ -567,7 +567,6 @@ remove_movement_ops = PatternMatcher([
    lambda st,const,view: const.replace(src=(st.replace(arg=st.st+view.st),)) if all(v.mask is None for v in (st.st+view.st).views) else None),
 ])
 
-@track_rewrites(named=True)
 def create_schedule_with_vars(outs:list[UOp], skip_check:bool=not __debug__) -> tuple[list[ScheduleItem], dict[Variable, int]]:
   if not skip_check: type_verify(list(UOp.sink(*outs).toposort), extra_spec=tensor_uop_spec)
   # to_uop is removing (many) of the movement ops

--- a/tinygrad/ops.py
+++ b/tinygrad/ops.py
@@ -851,6 +851,7 @@ class RewriteContext:
   def advance(self, uop:UOp, srcs:tuple) -> tuple:
     states = (0,)
     for src in srcs: states = tuple(self.pm.states[st][s] for st in states for s in (*src, None) if s in self.pm.states[st])
+    # TODO: add (0,) here to match pattern where this uop doesn't have srcs
     def _match(uop: UOp, ops, dtypes, arg):
       return (ops is None or uop.op in ops) and (dtypes is None or uop.dtype in dtypes or uop.dtype.scalar() in dtypes) and (arg is None or uop.arg == arg)
     states = tuple(self.pm.states[st][vals] for st in states for vals in self.pm.states[st] if isinstance(vals, tuple) and _match(uop, *vals))


### PR DESCRIPTION
I wanted to open this pr when it was fully working but I grew impatient, it's 90% there. The key insights are that matching should start at the leaf nodes instead of the root and the use of a [tree automaton](https://en.wikipedia.org/wiki/Tree_automaton).

The old matching had two key inefficiencies, both `match()` and `rewrite()` traverse the same uop multiple times.
Suppose we have the patterns `a(b,d)` `a(b,c)` and want to match target `a(b,c)` (each letter is a uop and tuple is the src). The matching sequence would be `a-b-d-a-b-c`. When d fails the match, the whole sequence starts over.
But match is called by rewrite which starts rewriting at the leaf nodes so the full rewrite sequence would be `b-c-a-b-d-a-b-c`.

With the new implementation the full sequence would be `b-c-a`. Each uop is traversed exactly once in the whole rewrite routine.

This [video](https://www.youtube.com/watch?v=ANf7FpHoq0w) is a good overview of a tree automata. With a leaf to root traversal we don't need to check the number of srcs.
To support repeated srcs and `allow_any_len` the srcs were decoupled so that the first src leads to the second etc. This way we can add transition values for repeats and variable length srcs.

Whether this results in a 2x or 20x speedup remains to be seen, but this is the correct way to implement a state machine for this context.

Here's the TODO list:
- [ ] correctly assign names to uops (somewhat tricky cause names aren't tied to states)
- [ ] add support for any src
- [ ] separate `op`, `dtype`, `arg` into their own states, each will be a simple lookup